### PR TITLE
schemas: forceer URI en date formaten

### DIFF
--- a/schemas/configuration.json
+++ b/schemas/configuration.json
@@ -6,26 +6,36 @@
       "type": "object",
       "properties": {
         "title": {
+          "description": "Titel van de specificatie",
           "type": "string"
         },
         "category": {
-          "type": "string"
+          "description": "Categorie van de specificatie als URI",
+          "type": "string",
+          "format": "uri"
         },
         "usage": {
-          "type": "string"
+          "description": "Gebruik van de specificatie als URI",
+          "type": "string",
+          "format": "uri"
         },
         "status": {
-          "type": "string"
+          "description": "Status van de specificatie als URI",
+          "type": "string",
+          "format": "uri"
         },
         "responsibleOrganisation": {
           "type": "array",
+          "description": "Organisatie verantwoordelijk voor de specificatie",
           "items": {
             "type": "object",
             "properties": {
               "name": {
+                "description": "Naam van de organisatie",
                 "type": "string"
               },
               "resourceReference": {
+                "description": "URI van de organisatie",
                 "type": "string"
               }
             },
@@ -33,36 +43,56 @@
           }
         },
         "publicationDate": {
-          "type": "string"
+          "description": "Publicatiedatum van de laatste versie",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date"
+            },
+            {
+              "type": "string",
+              "maxLength": 0
+            }
+          ]
         },
         "descriptionFileName": {
-          "type": "string"
+          "description": "Bestandsnaam naar het Markdown bestand met de samenvatting",
+          "type": "string",
+          "pattern": ".*\\.md"
         },
         "specificationDocuments": {
+          "description": "Specificatiedocumenten lijst",
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "name": {
+                "description": "Naam document",
                 "type": "string"
               },
               "resourceReference": {
-                "type": "string"
+                "description": "Link naar document",
+                "type": "string",
+                "format": "uri"
               }
             },
             "additionalProperties": false
           }
         },
         "documentation": {
+          "description": "Lijst van documentatie, niet-normatief",
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "name": {
+                "description": "Naam document",
                 "type": "string"
               },
               "resourceReference": {
-                "type": "string"
+                "description": "Link naar document",
+                "type": "string",
+                "format": "uri"
               }
             },
             "additionalProperties": false
@@ -70,63 +100,157 @@
         },
         "charter": {
           "type": "object",
+          "description": "Charter van de Werkgroep",
           "properties": {
             "name": {
+              "description": "Naam charterdocument van de Werkgroep",
               "type": "string"
             },
             "resourceReference": {
-              "type": "string"
+              "description": "Link naar charterdocument van de Werkgroep",
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uri",
+                  "pattern": "https:\\/\\/raw\\.githubusercontent\\.com.*\\.docx"
+                },
+                {
+                  "type": "string",
+                  "format": "uri",
+                  "pattern": "https:\\/\\/raw\\.githubusercontent\\.com.*\\.pdf"
+                }
+              ]
             }
           },
           "additionalProperties": false
         },
         "reports": {
           "type": "array",
+          "description": "Lijst met verslagen van de Werkgroep",
           "items": {
             "type": "object",
             "properties": {
               "name": {
+                "description": "Naam verslag",
                 "type": "string"
               },
               "resourceReference": {
-                "type": "string"
+                "description": "Link naar verslag",
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "uri",
+                    "pattern": "https:\\/\\/raw\\.githubusercontent\\.com.*\\.docx"
+                  },
+                  {
+                    "type": "string",
+                    "format": "uri",
+                    "pattern": "https:\\/\\/raw\\.githubusercontent\\.com.*\\.pdf"
+                  }
+                ]
               }
             },
             "additionalProperties": false
           }
         },
         "presentations": {
+          "description": "Lijst met presentaties van de Werkgroep",
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "name": {
+                "description": "Naam presentatie",
                 "type": "string"
               },
               "resourceReference": {
-                "type": "string"
+                "description": "Link naar presentatie",
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "uri",
+                    "pattern": "https:\\/\\/raw\\.githubusercontent\\.com.*\\.docx"
+                  },
+                  {
+                    "type": "string",
+                    "format": "uri",
+                    "pattern": "https:\\/\\/raw\\.githubusercontent\\.com.*\\.pdf"
+                  }
+                ]
               }
             },
             "additionalProperties": false
           }
         },
         "dateOfRegistration": {
-          "type": "string"
+          "description": "Datum registratie specificatie",
+          "type": "string",
+          "format": "date"
         },
         "dateOfAcknowledgementByWorkingGroup": {
-          "type": "string"
+          "description": "Datum herkenning specificatie door Werkgroep",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date"
+            },
+            {
+              "type": "string",
+              "maxLength": 0
+            }
+          ]
         },
         "dateOfAcknowledgementBySteeringCommittee": {
-          "type": "string"
+          "description": "Datum herkenning specificatie door Stuurgroep",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date"
+            },
+            {
+              "type": "string",
+              "maxLength": 0
+            }
+          ]
         },
         "datePublicReviewStart": {
-          "type": "string"
+          "description": "Begindatum publieke review",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date"
+            },
+            {
+              "type": "string",
+              "maxLength": 0
+            }
+          ]
         },
         "datePublicReviewEnd": {
-          "type": "string"
+          "description": "Einddatum publieke review",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date"
+            },
+            {
+              "type": "string",
+              "maxLength": 0
+            }
+          ]
         },
         "endOfPublicationDate": {
-          "type": "string"
+          "description": "Einddatum publicatie",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date"
+            },
+            {
+              "type": "string",
+              "maxLength": 0
+            }
+          ]
         }
       },
       "required": [


### PR DESCRIPTION
Vermijd dat men foutieve data of URIs in de standaarden configuratie plaatst door deze te verplichtingen via de JSON Schema check.

Voorkom tevens dat men resource links toevoegd die niet naar de resource zelf linken maar naar de GitHub repository waar de resource zou staan (enkel raw.githubusercontent.com nog toelaten).