### PR TITLE
README: voorzie template voor README ipv editors instructies

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -1,0 +1,21 @@
+# OSLOthema-mijnThema
+
+**_Editors:_**
+- first read [deze richtlijnen](https://github.com/Informatievlaanderen/OSLO-toolchain/blob/master/doc-user/README.md) .
+- Use [TagsAndNotes.xlsm](https://github.com/Informatievlaanderen/OSLO-allerleiTooltjes/tree/master/EA-Excel/TagsAndNotes) 
+  to edit tags in Excel. The files `*.xlsm` are included in the repo as git-ignored.
+
+
+## Administrative information
+
+### Tags
+To refer to the available git tags to create a publication point from, see the "Releases" tab of this repo.
+
+
+### Branches
+The organisation and meaning of the git branches are documented in this table.
+
+
+| Branch | Purpose | Active (y/n) |
+| ------ | --------- | ---------------- | 
+|  |  |  |

--- a/README.md
+++ b/README.md
@@ -1,21 +1,38 @@
-# OSLOthema-mijnThema
+# TITEL VAN TRAJECT
+<!--TODO: pas de titel aan van de README naar de naam van het traject zoals bijvoorbeeld 'Energiehuis'-->
 
-**_Editors:_**
-- first read [deze richtlijnen](https://github.com/Informatievlaanderen/OSLO-toolchain/blob/master/doc-user/README.md) .
-- Use [TagsAndNotes.xlsm](https://github.com/Informatievlaanderen/OSLO-allerleiTooltjes/tree/master/EA-Excel/TagsAndNotes) 
-  to edit tags in Excel. The files `*.xlsm` are included in the repo as git-ignored.
+## Inleiding
 
+<!--TODO: inleidende beschrijving van het traject-->
 
-## Administrative information
+## Verslagen en presentaties
 
-### Tags
-To refer to the available git tags to create a publication point from, see the "Releases" tab of this repo.
+De verslagen en presentaties van dit traject kan je terugvinden op het [Standaardenregister](https://data.vlaanderen.be/standaarden).
 
+## In deze repository
 
-### Branches
-The organisation and meaning of the git branches are documented in this table.
+<!--TODO: voeg de bestanden toe die hier gelinkt worden en vul de changelog aan -->
+EAP-files met de UML-diagrammen.\
+Configuratie en bestanden voor het publiceren van de specs in de folders config, site-skeleton en templates.\
+Een [changelog](./CHANGELOG) met wijzigingen tov vorige versies.\
+Diverse resources:
+- Een overzicht van de [use cases](./usecases.md)
+- Een overzicht van gebruikte [bronnen](./bronnen.md) (standaarden, implementaties, regelgeving).
+- Het [modelleringsrapport](./resources/Modelleerrapport.pdf).
+- Een map met [datavoorbeelden](./datavoorbeelden).
 
+## Issues
 
-| Branch | Purpose | Active (y/n) |
-| ------ | --------- | ---------------- | 
-|  |  |  |
+<!--TODO: pas de link aan naar het juiste repository -->
+Via de tab [issues](https://github.com/Informatievlaanderen/OSLOthema-PAS-ME-AAN/issues) kan je opmerkingen en feedback over het model geven.
+
+## Publicaties
+
+<!--TODO: pas de DATUM aan als de standaard voorgelegd is op de WG en toon deze lijn pas als dat gebeurd is -->
+<!--Volgende specificaties worden met de volgende status voorgelegd op WG datastandaarden van `DATUM`.-->
+
+<!--TODO: Pas de tabel aan met de standaarden die uit dit traject voortvloeien met hun status, uitgiftedatum en de nodige links naar het AP, VOC, of IMP. Indien enkel AP of VOC, laat andere links weg-->
+| Naam|Status|Uitgiftedatum|AP|VOC|IMP|
+| --- |--- |---|---|---|---|
+||||[Link]()|[Link]()|[Link]()|
+


### PR DESCRIPTION
Editor instructies staan onder EDITORS.md.

Dit PR zou er voor moeten zorgen dat editoren beter de READMEs in de repositories zullen aanvullen ipv die op de editor instructies te laten staan of enkel een titel  voorzien.